### PR TITLE
Alternative Pattern 64: A3 00 00 00 00

### DIFF
--- a/AntiDebugging.yara
+++ b/AntiDebugging.yara
@@ -209,7 +209,7 @@ rule DebuggerPattern__SEH_Inits : AntiDebug DebuggerPattern {
 	meta:
 		weight = 1
 	strings:
-		$ = {64 89 25 00 00 00 00}
+		$ = { 64 ( 89 25 | A3 ) 00 00 00 00 }
 	condition:
 		any of them
 }

--- a/AntiDebugging.yara
+++ b/AntiDebugging.yara
@@ -209,7 +209,8 @@ rule DebuggerPattern__SEH_Inits : AntiDebug DebuggerPattern {
 	meta:
 		weight = 1
 	strings:
-		$ = { 64 ( 89 25 | A3 ) 00 00 00 00 }
+		$a = { 64 A3 00 00 00 00 }
+		$b = { 64 89 25 00 00 00 00 }
 	condition:
-		any of them
+		$a or $b
 }


### PR DESCRIPTION
The following screenshot is of the SEH setup function:
https://i.imgur.com/8yQ5wi2.png

You can see at the bottom when the SEH is initialized, there is a different pattern. This could be due to compiler differences. I've adjusted the signature using alternatives. The sample this can be observed in is here: https://www.virustotal.com/gui/file/2fb00d9f9eee56523ac9fe61e7af8966ac60de6fdaf3ccd6214aae745ce2e922/detection